### PR TITLE
Fix run scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,4 +147,5 @@ Once registered you can define the dockerfile to use with `-f Dockerfile.aarch64
 
 ## Versions
 
+* **09.10.20:** - Fix run scripts evaluating `$` in cases where they should not (ex: inside single quotes). Please rerun the [Recommended method](https://github.com/linuxserver/docker-yq#recommended-method) install/setup commands.
 * **07.10.20:** - Initial Release.

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -150,6 +150,7 @@ full_custom_readme: |
 
   ## Versions
 
+  * **09.10.20:** - Fix run scripts evaluating `$` in cases where they should not (ex: inside single quotes). Please rerun the [Recommended method](https://github.com/linuxserver/docker-yq#recommended-method) install/setup commands.
   * **07.10.20:** - Initial Release.
 
   {%- endraw %}

--- a/run-jq.sh
+++ b/run-jq.sh
@@ -30,4 +30,5 @@ fi
 # Always set -i to support piped and terminal input in run/exec
 DOCKER_RUN_OPTIONS="${DOCKER_RUN_OPTIONS} -i"
 
-eval exec docker run --rm "${DOCKER_RUN_OPTIONS}" "${JQ_OPTIONS}" "${VOLUMES}" -w "${PWD}" --entrypoint jq "${IMAGE}" "$@"
+# shellcheck disable=SC2086
+exec docker run --rm ${DOCKER_RUN_OPTIONS} ${JQ_OPTIONS} ${VOLUMES} -w "${PWD}" --entrypoint jq "${IMAGE}" "$@"

--- a/run-xq.sh
+++ b/run-xq.sh
@@ -30,4 +30,5 @@ fi
 # Always set -i to support piped and terminal input in run/exec
 DOCKER_RUN_OPTIONS="${DOCKER_RUN_OPTIONS} -i"
 
-eval exec docker run --rm "${DOCKER_RUN_OPTIONS}" "${XQ_OPTIONS}" "${VOLUMES}" -w "${PWD}" --entrypoint xq "${IMAGE}" "$@"
+# shellcheck disable=SC2086
+exec docker run --rm ${DOCKER_RUN_OPTIONS} ${XQ_OPTIONS} ${VOLUMES} -w "${PWD}" --entrypoint xq "${IMAGE}" "$@"

--- a/run-yq.sh
+++ b/run-yq.sh
@@ -30,4 +30,5 @@ fi
 # Always set -i to support piped and terminal input in run/exec
 DOCKER_RUN_OPTIONS="${DOCKER_RUN_OPTIONS} -i"
 
-eval exec docker run --rm "${DOCKER_RUN_OPTIONS}" "${YQ_OPTIONS}" "${VOLUMES}" -w "${PWD}" --entrypoint yq "${IMAGE}" "$@"
+# shellcheck disable=SC2086
+exec docker run --rm ${DOCKER_RUN_OPTIONS} ${YQ_OPTIONS} ${VOLUMES} -w "${PWD}" --entrypoint yq "${IMAGE}" "$@"


### PR DESCRIPTION
Running things like `yq -y -s 'reduce .[] as $item ({}; . * $item)' *.yml` to merge yml files is broken! The `$item` is evaluated rather than being handed to `yq`. This fixes the issue (and unfortunately requires a shellcheck ignore). This method is what was originally used in the docker-compose run script.